### PR TITLE
replace different way of declaring color and opacity

### DIFF
--- a/pngs_from_svg.py
+++ b/pngs_from_svg.py
@@ -27,9 +27,15 @@ def create_images(svg, namebase):
         data = f.read()
         f.close()
 
+        data = data.replace( \
+            "style=\"fill:#000000;opacity:1\"",
+            "style=\"fill:" + color + ";opacity:" + str(opacity) + "\"")
         data = data.replace(
             "fill=\"#000000\"",
             "fill=\"" + color + "\"")
+        data = data.replace(
+            "style=\"fill:#000000\"",
+            "style=\"fill:" + color + "\"")
         data = data.replace(
             "fill-opacity=\"1.0\"",
             "fill-opacity=\"" + str(opacity) + "\"")


### PR DESCRIPTION
had some problems with some svg files where color and opacity was declared in a different way
