### PR TITLE
replace color in more elements

### DIFF
--- a/pngs_from_svg.py
+++ b/pngs_from_svg.py
@@ -28,10 +28,13 @@ def modify_svg(svg, tmp, color, opacity):
     root = tree.getroot()
 
     if color:
-        for path in tree.iter("{" + ns + "}path"):
-            if path.get('fill') != "none":
-                remove_color(path)
-                path.set("fill", color)
+        coloredShapes = ["path", "rect", "circle", "ellipse", "line", "polyline", "polygon", "text",
+                         "tspan", "tref", "textPath", "altGlyph", "altGlyphDef", "altGlyphItem", "glyphRef"]
+        for shape in coloredShapes:
+            for path in tree.iter("{" + ns + "}" + shape):
+                if path.get('fill') != "none":
+                    remove_color(path)
+                    path.set("fill", color)
 
     if opacity:
         opacityGroup = ElementTree.Element("g")


### PR DESCRIPTION
I had a problem generating a png from `ic_photo_camera` from the material icon repo. It has a `circle` element which isn't colored with the current version:

``` svg
<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
    <circle cx="24" cy="24" r="6.4"/>
    <path d="M18 4l-3.66 4h-6.34c-2.21 0-4 1.79-4 4v24c0 2.21 1.79 4 4 4h32c2.21 0 4-1.79 4-4v-24c0-2.21-1.79-4-4-4h-6.34l-3.66-4h-12zm6 30c-5.52 0-10-4.48-10-10s4.48-10 10-10 10 4.48 10 10-4.48 10-10 10z"/>
    <path d="M0 0h48v48h-48z" fill="none"/>
</svg>
```

So I looked in the [documentation](http://www.w3.org/TR/SVG/Overview.html) and added every element which made sense at the first glance ;) 
